### PR TITLE
Added advanced search and load from disk at init

### DIFF
--- a/src/natyla/core.go
+++ b/src/natyla/core.go
@@ -84,6 +84,10 @@ func init() {
 
 	collections = make(map[string]collectionChannel)
 
+	//Read collections from disk
+	nRead := readAllFromDisk()
+	fmt.Println("Read",nRead,"entries from disk")
+
 	fmt.Println("Ready, API Listening on http://localhost:8080, Telnet on port 8081")
 	fmt.Println("------------------------------------------------------------------")
 }

--- a/src/natyla/data/turu/1.json
+++ b/src/natyla/data/turu/1.json
@@ -1,1 +1,0 @@
-{"id":1,"name":"Grande"}

--- a/src/natyla/restApi.go
+++ b/src/natyla/restApi.go
@@ -56,6 +56,32 @@ func processRequest(w http.ResponseWriter, req *http.Request) {
 
 	case "GET":
 
+		//Search advanced. /cars?color:red;owner[]=Natalia;owner[]=Adriana
+		if len(comandos) == 1 {
+			fmt.Println("Search advanced for",comandos,"with",req.URL.Query())
+			collection := comandos[0]
+
+			err := req.ParseForm()
+
+			if err != nil {
+				fmt.Println(err)
+				w.WriteHeader(500)
+				return
+			}
+
+			//query is in req.Form after ParseForm is executed
+			result, err := advancedSearch(collection, req.Form)
+
+			if err != nil {
+				fmt.Println(result)
+				w.WriteHeader(500)
+				return
+			}
+
+			render(result,w,req)
+			return
+		}
+
 		//Serch for the specific field in the collection
 		if comandos[1] == "search" {
 			col := comandos[0]

--- a/src/natyla/search.go
+++ b/src/natyla/search.go
@@ -43,3 +43,41 @@ func search(col, key, value string) ([]byte, error) {
 
 	return b, err
 }
+
+
+func advancedSearch(collection string, query map[string][]string) ([]byte, error) 	{
+	arr := make([]interface{}, 0)
+	cc := collections[collection]
+
+	//Get each value from collection
+	for _, valueNode := range cc.Mapa {
+		//Compare fields that are inside query
+		docHasQueryField := false
+		wasMatched := true
+		for toMatchKey, toMatchValues := range query {
+			//With fields in the saved value if they exist
+			if suspect, ok := valueNode.Value.(node).V[toMatchKey]; ok {
+				docHasQueryField = true
+				//If value is json.Number compare as string
+				if reflect.TypeOf(suspect).String() == "json.Number" {
+					//For now compare only the first value from the Match Values array
+					if toMatchValues[0] != string(suspect.(json.Number)) {
+						wasMatched = false
+						break
+					}
+				} else if suspect != toMatchValues[0] {
+					wasMatched = false
+					break
+				}
+			}
+		}
+
+		if docHasQueryField && wasMatched {
+			arr = append(arr, valueNode.Value.(node).V)
+		}
+	}
+
+	b, err := json.Marshal(arr)
+
+	return b, err
+}

--- a/src/natyla/search_test.go
+++ b/src/natyla/search_test.go
@@ -53,6 +53,7 @@ func Test_search_a_resource_based_on_a_field(t *testing.T) {
 func TestSearchAResourceWithNumericField(t *testing.T) {
 	//delete the content from disk if it exists from previous tests
 	deleteJsonFromDisk("users", "2")
+	deleteJsonFromDisk("users", "3")
 
 	//define a json content
 	content1 := `{"age":24,"country":"Argentina","id":2,"name":"Natalia"}`
@@ -77,16 +78,52 @@ func TestSearchAResourceWithNumericField(t *testing.T) {
 	//search for a resource with age 15
 	response = get("/users/search?field=age&equal=15")
 
-	//Check the array with any resource
+	//Check the array with no resource
 	checkContent(t, response, "[]")
 
 	//search for a resource with age as string
 	response = get("/users/search?field=age&equal=two")
 
-	//Check the array with any resource
+	//Check the array with no resource
 	checkContent(t, response, "[]")
 
 	//cleanup
 	deleteJsonFromDisk("users", "2")
 	deleteJsonFromDisk("users", "3")
+}
+
+func TestAdvancedSearch(t *testing.T) {
+	//delete the content from disk if it exists from previous tests
+	deleteJsonFromDisk("users", "2")
+	deleteJsonFromDisk("users", "3")
+
+	//define a json content
+	content1 := `{"age":24,"country":"Argentina","id":2,"name":"Natalia"}`
+	content2 := `{"age":27,"country":"Argentina","id":3,"name":"Adriana"}`
+
+	//create the resource
+	post("/users", content1)
+	post("/users", content2)
+
+	//search for a resource with age 24 named Natalia
+	response := get("/users?age=24;name=Natalia")
+
+	//Check the array with only one resource
+	checkContent(t, response, "["+content1+"]")
+
+	//search for a resource with age 24 named Natalia
+	response = get("/users?age=27;name=Natalia")
+
+	//Check the array with no resource
+	checkContent(t, response, "[]")
+
+	//search for a resource with country Argentina age 27
+	response = get("/users?country=Argentina;age=27")
+
+	//Check the array with no resource
+	checkContent(t, response, "["+content2+"]")
+
+	deleteJsonFromDisk("users", "2")
+	deleteJsonFromDisk("users", "3")
+
 }


### PR DESCRIPTION
Added advanced search with multiple fields. Proposed search would be more RESTful with no verb in the URI.

Instead of:
* users/search?field=name&equal=Luis
you do:
* users?name=Luis

In the future if you would like to do comparisons you could do either of
* users?age=gt;15
* users?age=>15

I also added the capability to restore values from disk without the need executing getElement first. I found it quirky that in order to search for a value yo would have to get it first. Unless I am missing something in the design or intent of this project then I think it is necessary to be able to search for values after the system is restored from a crash.
